### PR TITLE
Add /dev/hwrng and rng-tools

### DIFF
--- a/PATCH/new/main/Support-hardware-random-number-generator-for-RK3328.patch
+++ b/PATCH/new/main/Support-hardware-random-number-generator-for-RK3328.patch
@@ -5,7 +5,6 @@ Subject: [PATCH] Support hardware random number generator for RK3328
 
 Signed-off-by: wevsty <ty@wevs.org>
 ---
- target/linux/rockchip/armv8/config-5.4        |   2 +
  ...rockchip-hardware-random-dev-support.patch | 385 ++++++++++++++++++
  ...rockchip-add-hardware-rng-for-RK3328.patch |  28 ++
  ...rockchip-add-hardware-rng-for-RK3399.patch |  27 ++
@@ -16,19 +15,6 @@ Signed-off-by: wevsty <ty@wevs.org>
  create mode 100644 target/linux/rockchip/patches-5.4/014-rockchip-add-hardware-rng-for-RK3399.patch
  create mode 100644 target/linux/rockchip/patches-5.4/015-rockchip-enable-hardware-rng-for-NanoPi-R2S.patch
 
-diff --git a/target/linux/rockchip/armv8/config-5.4 b/target/linux/rockchip/armv8/config-5.4
-index 368ed4e4b4..c23dcd89ff 100644
---- a/target/linux/rockchip/armv8/config-5.4
-+++ b/target/linux/rockchip/armv8/config-5.4
-@@ -192,6 +192,8 @@ 
- CONFIG_HWMON=y
- CONFIG_HWSPINLOCK=y
- CONFIG_HW_CONSOLE=y
-+CONFIG_HW_RANDOM=y
-+CONFIG_HW_RANDOM_ROCKCHIP=y
- # CONFIG_HZ_PERIODIC is not set
- CONFIG_I2C=y
- CONFIG_I2C_ALGOBIT=y
 diff --git a/target/linux/rockchip/patches-5.4/012-rockchip-hardware-random-dev-support.patch b/target/linux/rockchip/patches-5.4/012-rockchip-hardware-random-dev-support.patch
 new file mode 100644
 index 0000000000..b78e56b99c

--- a/PATCH/new/main/Support-hardware-random-number-generator-for-RK3328.patch
+++ b/PATCH/new/main/Support-hardware-random-number-generator-for-RK3328.patch
@@ -20,7 +20,7 @@ diff --git a/target/linux/rockchip/armv8/config-5.4 b/target/linux/rockchip/armv
 index 368ed4e4b4..c23dcd89ff 100644
 --- a/target/linux/rockchip/armv8/config-5.4
 +++ b/target/linux/rockchip/armv8/config-5.4
-@@ -192,6 +192,8 @@ CONFIG_HWMON=y
+@@ -192,6 +192,8 @@ 
  CONFIG_HWMON=y
  CONFIG_HWSPINLOCK=y
  CONFIG_HW_CONSOLE=y

--- a/PATCH/new/main/Support-hardware-random-number-generator-for-RK3328.patch
+++ b/PATCH/new/main/Support-hardware-random-number-generator-for-RK3328.patch
@@ -1,0 +1,512 @@
+From e5b5361651940ff5c0c1784dfd0130abec7ab535 Mon Sep 17 00:00:00 2001
+From: wevsty <ty@wevs.org>
+Date: Mon, 24 Aug 2020 02:27:11 +0800
+Subject: [PATCH] Support hardware random number generator for RK3328
+
+Signed-off-by: wevsty <ty@wevs.org>
+---
+ target/linux/rockchip/armv8/config-5.4        |   2 +
+ ...rockchip-hardware-random-dev-support.patch | 385 ++++++++++++++++++
+ ...rockchip-add-hardware-rng-for-RK3328.patch |  28 ++
+ ...rockchip-add-hardware-rng-for-RK3399.patch |  27 ++
+ ...p-enable-hardware-rng-for-NanoPi-R2S.patch |  17 +
+ 5 files changed, 459 insertions(+)
+ create mode 100644 target/linux/rockchip/patches-5.4/012-rockchip-hardware-random-dev-support.patch
+ create mode 100644 target/linux/rockchip/patches-5.4/013-rockchip-add-hardware-rng-for-RK3328.patch
+ create mode 100644 target/linux/rockchip/patches-5.4/014-rockchip-add-hardware-rng-for-RK3399.patch
+ create mode 100644 target/linux/rockchip/patches-5.4/015-rockchip-enable-hardware-rng-for-NanoPi-R2S.patch
+
+diff --git a/target/linux/rockchip/armv8/config-5.4 b/target/linux/rockchip/armv8/config-5.4
+index 368ed4e4b4..c23dcd89ff 100644
+--- a/target/linux/rockchip/armv8/config-5.4
++++ b/target/linux/rockchip/armv8/config-5.4
+@@ -192,6 +192,8 @@ CONFIG_HWMON=y
+ CONFIG_HWMON=y
+ CONFIG_HWSPINLOCK=y
+ CONFIG_HW_CONSOLE=y
++CONFIG_HW_RANDOM=y
++CONFIG_HW_RANDOM_ROCKCHIP=y
+ # CONFIG_HZ_PERIODIC is not set
+ CONFIG_I2C=y
+ CONFIG_I2C_ALGOBIT=y
+diff --git a/target/linux/rockchip/patches-5.4/012-rockchip-hardware-random-dev-support.patch b/target/linux/rockchip/patches-5.4/012-rockchip-hardware-random-dev-support.patch
+new file mode 100644
+index 0000000000..b78e56b99c
+--- /dev/null
++++ b/target/linux/rockchip/patches-5.4/012-rockchip-hardware-random-dev-support.patch
+@@ -0,0 +1,385 @@
++From: wevsty <ty@wevs.org>
++Subject: Support for rockchip hardware random number generator
++
++This patch provides hardware random number generator support for all rockchip SOC.
++
++rockchip-rng.c from  https://github.com/rockchip-linux/kernel/blob/develop-4.4/drivers/char/hw_random/rockchip-rng.c
++
++Signed-off-by: wevsty <ty@wevs.org>
++---
++
++--- a/drivers/char/hw_random/Kconfig
+++++ b/drivers/char/hw_random/Kconfig
++@@ -345,6 +345,19 @@ config HW_RANDOM_STM32
++ 
++ 	  If unsure, say N.
++ 
+++config HW_RANDOM_ROCKCHIP
+++	tristate "Rockchip Random Number Generator support"
+++	depends on ARCH_ROCKCHIP
+++	default HW_RANDOM
+++	help
+++	  This driver provides kernel-side support for the Random Number
+++	  Generator hardware found on Rockchip cpus.
+++
+++	  To compile this driver as a module, choose M here: the
+++	  module will be called rockchip-rng.
+++
+++	  If unsure, say Y.
+++
++ config HW_RANDOM_PIC32
++ 	tristate "Microchip PIC32 Random Number Generator support"
++ 	depends on HW_RANDOM && MACH_PIC32
++--- /dev/null
+++++ b/drivers/char/hw_random/rockchip-rng.c
++@@ -0,0 +1,340 @@
+++// SPDX-License-Identifier: GPL-2.0
+++/*
+++ * rockchip-rng.c Random Number Generator driver for the Rockchip
+++ *
+++ * Copyright (c) 2018, Fuzhou Rockchip Electronics Co., Ltd.
+++ * Author: Lin Jinhan <troy.lin@rock-chips.com>
+++ *
+++ */
+++#include <linux/clk.h>
+++#include <linux/hw_random.h>
+++#include <linux/iopoll.h>
+++#include <linux/module.h>
+++#include <linux/mod_devicetable.h>
+++#include <linux/of.h>
+++#include <linux/platform_device.h>
+++#include <linux/pm_runtime.h>
+++
+++#define _SBF(s, v)	((v) << (s))
+++#define HIWORD_UPDATE(val, mask, shift) \
+++			((val) << (shift) | (mask) << ((shift) + 16))
+++
+++#define ROCKCHIP_AUTOSUSPEND_DELAY		100
+++#define ROCKCHIP_POLL_PERIOD_US			100
+++#define ROCKCHIP_POLL_TIMEOUT_US		10000
+++#define RK_MAX_RNG_BYTE				(32)
+++
+++/* start of CRYPTO V1 register define */
+++#define CRYPTO_V1_CTRL				0x0008
+++#define CRYPTO_V1_RNG_START			BIT(8)
+++#define CRYPTO_V1_RNG_FLUSH			BIT(9)
+++
+++#define CRYPTO_V1_TRNG_CTRL			0x0200
+++#define CRYPTO_V1_OSC_ENABLE			BIT(16)
+++#define CRYPTO_V1_TRNG_SAMPLE_PERIOD(x)		(x)
+++
+++#define CRYPTO_V1_TRNG_DOUT_0			0x0204
+++/* end of CRYPTO V1 register define */
+++
+++/* start of CRYPTO V2 register define */
+++#define CRYPTO_V2_RNG_CTL			0x0400
+++#define CRYPTO_V2_RNG_64_BIT_LEN		_SBF(4, 0x00)
+++#define CRYPTO_V2_RNG_128_BIT_LEN		_SBF(4, 0x01)
+++#define CRYPTO_V2_RNG_192_BIT_LEN		_SBF(4, 0x02)
+++#define CRYPTO_V2_RNG_256_BIT_LEN		_SBF(4, 0x03)
+++#define CRYPTO_V2_RNG_FATESY_SOC_RING		_SBF(2, 0x00)
+++#define CRYPTO_V2_RNG_SLOWER_SOC_RING_0		_SBF(2, 0x01)
+++#define CRYPTO_V2_RNG_SLOWER_SOC_RING_1		_SBF(2, 0x02)
+++#define CRYPTO_V2_RNG_SLOWEST_SOC_RING		_SBF(2, 0x03)
+++#define CRYPTO_V2_RNG_ENABLE			BIT(1)
+++#define CRYPTO_V2_RNG_START			BIT(0)
+++#define CRYPTO_V2_RNG_SAMPLE_CNT		0x0404
+++#define CRYPTO_V2_RNG_DOUT_0			0x0410
+++/* end of CRYPTO V2 register define */
+++
+++struct rk_rng_soc_data {
+++	const char * const *clks;
+++	int clks_num;
+++	int (*rk_rng_read)(struct hwrng *rng, void *buf, size_t max, bool wait);
+++};
+++
+++struct rk_rng {
+++	struct device		*dev;
+++	struct hwrng		rng;
+++	void __iomem		*mem;
+++	struct rk_rng_soc_data	*soc_data;
+++	u32			clk_num;
+++	struct clk_bulk_data	*clk_bulks;
+++};
+++
+++static const char * const rk_rng_v1_clks[] = {
+++	"hclk_crypto",
+++	"clk_crypto",
+++};
+++
+++static const char * const rk_rng_v2_clks[] = {
+++	"hclk_crypto",
+++	"aclk_crypto",
+++	"clk_crypto",
+++	"clk_crypto_apk",
+++};
+++
+++static void rk_rng_writel(struct rk_rng *rng, u32 val, u32 offset)
+++{
+++	__raw_writel(val, rng->mem + offset);
+++}
+++
+++static u32 rk_rng_readl(struct rk_rng *rng, u32 offset)
+++{
+++	return __raw_readl(rng->mem + offset);
+++}
+++
+++static int rk_rng_init(struct hwrng *rng)
+++{
+++	int ret;
+++	struct rk_rng *rk_rng = container_of(rng, struct rk_rng, rng);
+++
+++	dev_dbg(rk_rng->dev, "clk_bulk_prepare_enable.\n");
+++
+++	ret = clk_bulk_prepare_enable(rk_rng->clk_num, rk_rng->clk_bulks);
+++	if (ret < 0) {
+++		dev_err(rk_rng->dev, "failed to enable clks %d\n", ret);
+++		return ret;
+++	}
+++
+++	return 0;
+++}
+++
+++static void rk_rng_cleanup(struct hwrng *rng)
+++{
+++	struct rk_rng *rk_rng = container_of(rng, struct rk_rng, rng);
+++
+++	dev_dbg(rk_rng->dev, "clk_bulk_disable_unprepare.\n");
+++	clk_bulk_disable_unprepare(rk_rng->clk_num, rk_rng->clk_bulks);
+++}
+++
+++static void rk_rng_read_regs(struct rk_rng *rng, u32 offset, void *buf,
+++			     size_t size)
+++{
+++	u32 i;
+++
+++	for (i = 0; i < size; i += 4)
+++		*(u32 *)(buf + i) = be32_to_cpu(rk_rng_readl(rng, offset + i));
+++}
+++
+++static int rk_rng_v1_read(struct hwrng *rng, void *buf, size_t max, bool wait)
+++{
+++	int ret = 0;
+++	u32 reg_ctrl = 0;
+++	struct rk_rng *rk_rng = container_of(rng, struct rk_rng, rng);
+++
+++	ret = pm_runtime_get_sync(rk_rng->dev);
+++	if (ret < 0) {
+++		pm_runtime_put_noidle(rk_rng->dev);
+++		return ret;
+++	}
+++
+++	/* enable osc_ring to get entropy, sample period is set as 100 */
+++	reg_ctrl = CRYPTO_V1_OSC_ENABLE | CRYPTO_V1_TRNG_SAMPLE_PERIOD(100);
+++	rk_rng_writel(rk_rng, reg_ctrl, CRYPTO_V1_TRNG_CTRL);
+++
+++	reg_ctrl = HIWORD_UPDATE(CRYPTO_V1_RNG_START, CRYPTO_V1_RNG_START, 0);
+++
+++	rk_rng_writel(rk_rng, reg_ctrl, CRYPTO_V1_CTRL);
+++
+++	ret = readl_poll_timeout(rk_rng->mem + CRYPTO_V1_CTRL, reg_ctrl,
+++				 !(reg_ctrl & CRYPTO_V1_RNG_START),
+++				 ROCKCHIP_POLL_PERIOD_US,
+++				 ROCKCHIP_POLL_TIMEOUT_US);
+++	if (ret < 0)
+++		goto out;
+++
+++	ret = min_t(size_t, max, RK_MAX_RNG_BYTE);
+++
+++	rk_rng_read_regs(rk_rng, CRYPTO_V1_TRNG_DOUT_0, buf, ret);
+++
+++out:
+++	/* close TRNG */
+++	rk_rng_writel(rk_rng, HIWORD_UPDATE(0, CRYPTO_V1_RNG_START, 0),
+++		      CRYPTO_V1_CTRL);
+++
+++	pm_runtime_mark_last_busy(rk_rng->dev);
+++	pm_runtime_put_sync_autosuspend(rk_rng->dev);
+++
+++	return ret;
+++}
+++
+++static int rk_rng_v2_read(struct hwrng *rng, void *buf, size_t max, bool wait)
+++{
+++	int ret = 0;
+++	u32 reg_ctrl = 0;
+++	struct rk_rng *rk_rng = container_of(rng, struct rk_rng, rng);
+++
+++	ret = pm_runtime_get_sync(rk_rng->dev);
+++	if (ret < 0) {
+++		pm_runtime_put_noidle(rk_rng->dev);
+++		return ret;
+++	}
+++
+++	/* enable osc_ring to get entropy, sample period is set as 100 */
+++	rk_rng_writel(rk_rng, 100, CRYPTO_V2_RNG_SAMPLE_CNT);
+++
+++	reg_ctrl |= CRYPTO_V2_RNG_256_BIT_LEN;
+++	reg_ctrl |= CRYPTO_V2_RNG_SLOWER_SOC_RING_0;
+++	reg_ctrl |= CRYPTO_V2_RNG_ENABLE;
+++	reg_ctrl |= CRYPTO_V2_RNG_START;
+++
+++	rk_rng_writel(rk_rng, HIWORD_UPDATE(reg_ctrl, 0xffff, 0),
+++			CRYPTO_V2_RNG_CTL);
+++
+++	ret = readl_poll_timeout(rk_rng->mem + CRYPTO_V2_RNG_CTL, reg_ctrl,
+++				 !(reg_ctrl & CRYPTO_V2_RNG_START),
+++				 ROCKCHIP_POLL_PERIOD_US,
+++				 ROCKCHIP_POLL_TIMEOUT_US);
+++	if (ret < 0)
+++		goto out;
+++
+++	ret = min_t(size_t, max, RK_MAX_RNG_BYTE);
+++
+++	rk_rng_read_regs(rk_rng, CRYPTO_V2_RNG_DOUT_0, buf, ret);
+++
+++out:
+++	/* close TRNG */
+++	rk_rng_writel(rk_rng, HIWORD_UPDATE(0, 0xffff, 0), CRYPTO_V2_RNG_CTL);
+++
+++	pm_runtime_mark_last_busy(rk_rng->dev);
+++	pm_runtime_put_sync_autosuspend(rk_rng->dev);
+++
+++	return ret;
+++}
+++
+++static const struct rk_rng_soc_data rk_rng_v1_soc_data = {
+++	.clks_num = ARRAY_SIZE(rk_rng_v1_clks),
+++	.clks = rk_rng_v1_clks,
+++	.rk_rng_read = rk_rng_v1_read,
+++};
+++
+++static const struct rk_rng_soc_data rk_rng_v2_soc_data = {
+++	.clks_num = ARRAY_SIZE(rk_rng_v2_clks),
+++	.clks = rk_rng_v2_clks,
+++	.rk_rng_read = rk_rng_v2_read,
+++};
+++
+++static const struct of_device_id rk_rng_dt_match[] = {
+++	{
+++		.compatible = "rockchip,cryptov1-rng",
+++		.data = (void *)&rk_rng_v1_soc_data,
+++	},
+++	{
+++		.compatible = "rockchip,cryptov2-rng",
+++		.data = (void *)&rk_rng_v2_soc_data,
+++	},
+++	{ },
+++};
+++
+++MODULE_DEVICE_TABLE(of, rk_rng_dt_match);
+++
+++static int rk_rng_probe(struct platform_device *pdev)
+++{
+++	int i;
+++	int ret;
+++	struct rk_rng *rk_rng;
+++	struct device_node *np = pdev->dev.of_node;
+++	const struct of_device_id *match;
+++
+++	dev_dbg(&pdev->dev, "probing...\n");
+++	rk_rng = devm_kzalloc(&pdev->dev, sizeof(struct rk_rng), GFP_KERNEL);
+++	if (!rk_rng)
+++		return -ENOMEM;
+++
+++	match = of_match_node(rk_rng_dt_match, np);
+++	rk_rng->soc_data = (struct rk_rng_soc_data *)match->data;
+++
+++	rk_rng->dev = &pdev->dev;
+++	rk_rng->rng.name    = "rockchip";
+++#ifndef CONFIG_PM
+++	rk_rng->rng.init    = rk_rng_init;
+++	rk_rng->rng.cleanup = rk_rng_cleanup,
+++#endif
+++	rk_rng->rng.read    = rk_rng->soc_data->rk_rng_read;
+++	rk_rng->rng.quality = 999;
+++
+++	rk_rng->clk_bulks =
+++		devm_kzalloc(&pdev->dev, sizeof(*rk_rng->clk_bulks) *
+++			     rk_rng->soc_data->clks_num, GFP_KERNEL);
+++
+++	rk_rng->clk_num = rk_rng->soc_data->clks_num;
+++
+++	for (i = 0; i < rk_rng->soc_data->clks_num; i++)
+++		rk_rng->clk_bulks[i].id = rk_rng->soc_data->clks[i];
+++
+++	rk_rng->mem = devm_of_iomap(&pdev->dev, pdev->dev.of_node, 0, NULL);
+++	if (IS_ERR(rk_rng->mem))
+++		return PTR_ERR(rk_rng->mem);
+++
+++	ret = devm_clk_bulk_get(&pdev->dev, rk_rng->clk_num,
+++				rk_rng->clk_bulks);
+++	if (ret) {
+++		dev_err(&pdev->dev, "failed to get clks property\n");
+++		return ret;
+++	}
+++
+++	platform_set_drvdata(pdev, rk_rng);
+++
+++	pm_runtime_set_autosuspend_delay(&pdev->dev,
+++					ROCKCHIP_AUTOSUSPEND_DELAY);
+++	pm_runtime_use_autosuspend(&pdev->dev);
+++	pm_runtime_enable(&pdev->dev);
+++
+++	ret = devm_hwrng_register(&pdev->dev, &rk_rng->rng);
+++	if (ret) {
+++		pm_runtime_dont_use_autosuspend(&pdev->dev);
+++		pm_runtime_disable(&pdev->dev);
+++	}
+++
+++	return ret;
+++}
+++
+++#ifdef CONFIG_PM
+++static int rk_rng_runtime_suspend(struct device *dev)
+++{
+++	struct rk_rng *rk_rng = dev_get_drvdata(dev);
+++
+++	rk_rng_cleanup(&rk_rng->rng);
+++
+++	return 0;
+++}
+++
+++static int rk_rng_runtime_resume(struct device *dev)
+++{
+++	struct rk_rng *rk_rng = dev_get_drvdata(dev);
+++
+++	return rk_rng_init(&rk_rng->rng);
+++}
+++
+++static const struct dev_pm_ops rk_rng_pm_ops = {
+++	SET_RUNTIME_PM_OPS(rk_rng_runtime_suspend,
+++				rk_rng_runtime_resume, NULL)
+++	SET_SYSTEM_SLEEP_PM_OPS(pm_runtime_force_suspend,
+++				pm_runtime_force_resume)
+++};
+++
+++#endif
+++
+++static struct platform_driver rk_rng_driver = {
+++	.driver	= {
+++		.name	= "rockchip-rng",
+++#ifdef CONFIG_PM
+++		.pm	= &rk_rng_pm_ops,
+++#endif
+++		.of_match_table = rk_rng_dt_match,
+++	},
+++	.probe	= rk_rng_probe,
+++};
+++
+++module_platform_driver(rk_rng_driver);
+++
+++MODULE_DESCRIPTION("ROCKCHIP H/W Random Number Generator driver");
+++MODULE_AUTHOR("Lin Jinhan <troy.lin@rock-chips.com>");
+++MODULE_LICENSE("GPL v2");
+++
++--- a/drivers/char/hw_random/Makefile
+++++ b/drivers/char/hw_random/Makefile
++@@ -32,6 +32,7 @@ obj-$(CONFIG_HW_RANDOM_IPROC_RNG200) +=
++ obj-$(CONFIG_HW_RANDOM_ST) += st-rng.o
++ obj-$(CONFIG_HW_RANDOM_XGENE) += xgene-rng.o
++ obj-$(CONFIG_HW_RANDOM_STM32) += stm32-rng.o
+++obj-$(CONFIG_HW_RANDOM_ROCKCHIP) += rockchip-rng.o
++ obj-$(CONFIG_HW_RANDOM_PIC32) += pic32-rng.o
++ obj-$(CONFIG_HW_RANDOM_MESON) += meson-rng.o
++ obj-$(CONFIG_HW_RANDOM_CAVIUM) += cavium-rng.o cavium-rng-vf.o
+diff --git a/target/linux/rockchip/patches-5.4/013-rockchip-add-hardware-rng-for-RK3328.patch b/target/linux/rockchip/patches-5.4/013-rockchip-add-hardware-rng-for-RK3328.patch
+new file mode 100644
+index 0000000000..1102a44b0f
+--- /dev/null
++++ b/target/linux/rockchip/patches-5.4/013-rockchip-add-hardware-rng-for-RK3328.patch
+@@ -0,0 +1,28 @@
++From: wevsty <ty@wevs.org>
++Subject: Add hardware random number generator for RK3328
++
++Adding Hardware Random Number Generator Resources to the RK3328.
++
++Signed-off-by: wevsty <ty@wevs.org>
++---
++
++--- a/arch/arm64/boot/dts/rockchip/rk3328.dtsi
+++++ b/arch/arm64/boot/dts/rockchip/rk3328.dtsi
++@@ -269,6 +269,17 @@
++ 		status = "disabled";
++ 	};
++ 
+++	rng: rng@ff060000 {
+++		compatible = "rockchip,cryptov1-rng";
+++		reg = <0x0 0xff060000 0x0 0x4000>;
+++
+++		clocks = <&cru SCLK_CRYPTO>, <&cru HCLK_CRYPTO_SLV>;
+++		clock-names = "clk_crypto", "hclk_crypto";
+++		assigned-clocks = <&cru SCLK_CRYPTO>, <&cru HCLK_CRYPTO_SLV>;
+++		assigned-clock-rates = <150000000>, <100000000>;
+++		status = "disabled";
+++	};
+++
++ 	grf: syscon@ff100000 {
++ 		compatible = "rockchip,rk3328-grf", "syscon", "simple-mfd";
++ 		reg = <0x0 0xff100000 0x0 0x1000>;
+diff --git a/target/linux/rockchip/patches-5.4/014-rockchip-add-hardware-rng-for-RK3399.patch b/target/linux/rockchip/patches-5.4/014-rockchip-add-hardware-rng-for-RK3399.patch
+new file mode 100644
+index 0000000000..7c418ca24f
+--- /dev/null
++++ b/target/linux/rockchip/patches-5.4/014-rockchip-add-hardware-rng-for-RK3399.patch
+@@ -0,0 +1,27 @@
++From: wevsty <ty@wevs.org>
++Subject: Add hardware random number generator for RK3399
++
++Adding Hardware Random Number Generator Resources to the RK3399.
++
++Signed-off-by: wevsty <ty@wevs.org>
++---
++
++--- a/arch/arm64/boot/dts/rockchip/rk3399.dtsi
+++++ b/arch/arm64/boot/dts/rockchip/rk3399.dtsi
++@@ -1886,6 +1886,16 @@
++ 		};
++ 	};
++ 
+++	rng: rng@ff8b8000 {
+++		compatible = "rockchip,cryptov1-rng";
+++		reg = <0x0 0xff8b8000 0x0 0x1000>;
+++		clocks = <&cru SCLK_CRYPTO1>, <&cru HCLK_S_CRYPTO1>;
+++		clock-names = "clk_crypto", "hclk_crypto";
+++		assigned-clocks = <&cru SCLK_CRYPTO1>, <&cru HCLK_S_CRYPTO1>;
+++		assigned-clock-rates = <150000000>, <100000000>;
+++		status = "disabled";
+++	};
+++
++ 	gpu: gpu@ff9a0000 {
++ 		compatible = "rockchip,rk3399-mali", "arm,mali-t860";
++ 		reg = <0x0 0xff9a0000 0x0 0x10000>;
+diff --git a/target/linux/rockchip/patches-5.4/015-rockchip-enable-hardware-rng-for-NanoPi-R2S.patch b/target/linux/rockchip/patches-5.4/015-rockchip-enable-hardware-rng-for-NanoPi-R2S.patch
+new file mode 100644
+index 0000000000..b656f03140
+--- /dev/null
++++ b/target/linux/rockchip/patches-5.4/015-rockchip-enable-hardware-rng-for-NanoPi-R2S.patch
+@@ -0,0 +1,17 @@
++From: wevsty <ty@wevs.org>
++Subject: Enable hardware random number generator for RK3328
++
++
++Signed-off-by: wevsty <ty@wevs.org>
++---
++
++--- a/arch/arm64/boot/dts/rockchip/rk3328-nanopi-r2s.dts
+++++ b/arch/arm64/boot/dts/rockchip/rk3328-nanopi-r2s.dts
++@@ -140,3 +140,7 @@
++ 		};
++ 	};
++ };
+++
+++&rng {
+++	status = "okay";
+++};

--- a/PATCH/new/main/Support-hardware-random-number-generator-for-RK3328.patch
+++ b/PATCH/new/main/Support-hardware-random-number-generator-for-RK3328.patch
@@ -5,6 +5,7 @@ Subject: [PATCH] Support hardware random number generator for RK3328
 
 Signed-off-by: wevsty <ty@wevs.org>
 ---
+ target/linux/rockchip/armv8/config-5.4        |   2 +
  ...rockchip-hardware-random-dev-support.patch | 385 ++++++++++++++++++
  ...rockchip-add-hardware-rng-for-RK3328.patch |  28 ++
  ...rockchip-add-hardware-rng-for-RK3399.patch |  27 ++
@@ -15,11 +16,21 @@ Signed-off-by: wevsty <ty@wevs.org>
  create mode 100644 target/linux/rockchip/patches-5.4/014-rockchip-add-hardware-rng-for-RK3399.patch
  create mode 100644 target/linux/rockchip/patches-5.4/015-rockchip-enable-hardware-rng-for-NanoPi-R2S.patch
 
-diff --git a/target/linux/rockchip/patches-5.4/012-rockchip-hardware-random-dev-support.patch b/target/linux/rockchip/patches-5.4/012-rockchip-hardware-random-dev-support.patch
-new file mode 100644
-index 0000000000..b78e56b99c
---- /dev/null
-+++ b/target/linux/rockchip/patches-5.4/012-rockchip-hardware-random-dev-support.patch
+diff -rNEZbwBdu3 a/target/linux/rockchip/armv8/config-5.4 b/target/linux/rockchip/armv8/config-5.4
+--- a/target/linux/rockchip/armv8/config-5.4	2020-08-27 16:16:43.088264763 +0800
++++ b/target/linux/rockchip/armv8/config-5.4	2020-08-27 16:20:13.937869695 +0800
+@@ -182,6 +182,8 @@
+ CONFIG_HWMON=y
+ CONFIG_HWSPINLOCK=y
+ CONFIG_HW_CONSOLE=y
++CONFIG_HW_RANDOM=y
++CONFIG_HW_RANDOM_ROCKCHIP=y
+ # CONFIG_HZ_PERIODIC is not set
+ CONFIG_I2C=y
+ CONFIG_I2C_ALGOBIT=y
+diff -rNEZbwBdu3 a/target/linux/rockchip/patches-5.4/012-rockchip-hardware-random-dev-support.patch b/target/linux/rockchip/patches-5.4/012-rockchip-hardware-random-dev-support.patch
+--- a/target/linux/rockchip/patches-5.4/012-rockchip-hardware-random-dev-support.patch	1970-01-01 08:00:00.000000000 +0800
++++ b/target/linux/rockchip/patches-5.4/012-rockchip-hardware-random-dev-support.patch	2020-08-27 16:19:22.785477444 +0800
 @@ -0,0 +1,385 @@
 +From: wevsty <ty@wevs.org>
 +Subject: Support for rockchip hardware random number generator
@@ -406,11 +417,9 @@ index 0000000000..b78e56b99c
 + obj-$(CONFIG_HW_RANDOM_PIC32) += pic32-rng.o
 + obj-$(CONFIG_HW_RANDOM_MESON) += meson-rng.o
 + obj-$(CONFIG_HW_RANDOM_CAVIUM) += cavium-rng.o cavium-rng-vf.o
-diff --git a/target/linux/rockchip/patches-5.4/013-rockchip-add-hardware-rng-for-RK3328.patch b/target/linux/rockchip/patches-5.4/013-rockchip-add-hardware-rng-for-RK3328.patch
-new file mode 100644
-index 0000000000..1102a44b0f
---- /dev/null
-+++ b/target/linux/rockchip/patches-5.4/013-rockchip-add-hardware-rng-for-RK3328.patch
+diff -rNEZbwBdu3 a/target/linux/rockchip/patches-5.4/013-rockchip-add-hardware-rng-for-RK3328.patch b/target/linux/rockchip/patches-5.4/013-rockchip-add-hardware-rng-for-RK3328.patch
+--- a/target/linux/rockchip/patches-5.4/013-rockchip-add-hardware-rng-for-RK3328.patch	1970-01-01 08:00:00.000000000 +0800
++++ b/target/linux/rockchip/patches-5.4/013-rockchip-add-hardware-rng-for-RK3328.patch	2020-08-27 16:19:22.785477444 +0800
 @@ -0,0 +1,28 @@
 +From: wevsty <ty@wevs.org>
 +Subject: Add hardware random number generator for RK3328
@@ -440,11 +449,9 @@ index 0000000000..1102a44b0f
 + 	grf: syscon@ff100000 {
 + 		compatible = "rockchip,rk3328-grf", "syscon", "simple-mfd";
 + 		reg = <0x0 0xff100000 0x0 0x1000>;
-diff --git a/target/linux/rockchip/patches-5.4/014-rockchip-add-hardware-rng-for-RK3399.patch b/target/linux/rockchip/patches-5.4/014-rockchip-add-hardware-rng-for-RK3399.patch
-new file mode 100644
-index 0000000000..7c418ca24f
---- /dev/null
-+++ b/target/linux/rockchip/patches-5.4/014-rockchip-add-hardware-rng-for-RK3399.patch
+diff -rNEZbwBdu3 a/target/linux/rockchip/patches-5.4/014-rockchip-add-hardware-rng-for-RK3399.patch b/target/linux/rockchip/patches-5.4/014-rockchip-add-hardware-rng-for-RK3399.patch
+--- a/target/linux/rockchip/patches-5.4/014-rockchip-add-hardware-rng-for-RK3399.patch	1970-01-01 08:00:00.000000000 +0800
++++ b/target/linux/rockchip/patches-5.4/014-rockchip-add-hardware-rng-for-RK3399.patch	2020-08-27 16:19:22.785477444 +0800
 @@ -0,0 +1,27 @@
 +From: wevsty <ty@wevs.org>
 +Subject: Add hardware random number generator for RK3399
@@ -473,11 +480,9 @@ index 0000000000..7c418ca24f
 + 	gpu: gpu@ff9a0000 {
 + 		compatible = "rockchip,rk3399-mali", "arm,mali-t860";
 + 		reg = <0x0 0xff9a0000 0x0 0x10000>;
-diff --git a/target/linux/rockchip/patches-5.4/015-rockchip-enable-hardware-rng-for-NanoPi-R2S.patch b/target/linux/rockchip/patches-5.4/015-rockchip-enable-hardware-rng-for-NanoPi-R2S.patch
-new file mode 100644
-index 0000000000..b656f03140
---- /dev/null
-+++ b/target/linux/rockchip/patches-5.4/015-rockchip-enable-hardware-rng-for-NanoPi-R2S.patch
+diff -rNEZbwBdu3 a/target/linux/rockchip/patches-5.4/015-rockchip-enable-hardware-rng-for-NanoPi-R2S.patch b/target/linux/rockchip/patches-5.4/015-rockchip-enable-hardware-rng-for-NanoPi-R2S.patch
+--- a/target/linux/rockchip/patches-5.4/015-rockchip-enable-hardware-rng-for-NanoPi-R2S.patch	1970-01-01 08:00:00.000000000 +0800
++++ b/target/linux/rockchip/patches-5.4/015-rockchip-enable-hardware-rng-for-NanoPi-R2S.patch	2020-08-27 16:19:22.785477444 +0800
 @@ -0,0 +1,17 @@
 +From: wevsty <ty@wevs.org>
 +Subject: Enable hardware random number generator for RK3328

--- a/SCRIPTS/02_prepare_package.sh
+++ b/SCRIPTS/02_prepare_package.sh
@@ -2,8 +2,10 @@
 clear
 
 #Kernel
-#wget -O- https://patch-diff.githubusercontent.com/raw/openwrt/openwrt/pull/3320.patch | patch -p1
 wget -O- https://patch-diff.githubusercontent.com/raw/openwrt/openwrt/pull/3277.patch | patch -p1
+
+#HW-RNG
+wget -O- https://patch-diff.githubusercontent.com/raw/jayanta525/openwrt-nanopi-r2s/pull/9.patch | patch -p1
 
 #Crypto（test
 #wget -O- https://github.com/AmadeusGhost/lede/commit/3e668936669080ca6f3fcea5534b94d00103291a.patch | patch -p1

--- a/SCRIPTS/02_prepare_package.sh
+++ b/SCRIPTS/02_prepare_package.sh
@@ -5,7 +5,7 @@ clear
 wget -O- https://patch-diff.githubusercontent.com/raw/openwrt/openwrt/pull/3277.patch | patch -p1
 
 #HW-RNG
-patch -p1 < ../PATCH/new/main/Support-hardware-random-number-generator-for-RK3328.patch
+git apply ../PATCH/new/main/Support-hardware-random-number-generator-for-RK3328.patch
 
 #Crypto（test
 #wget -O- https://github.com/AmadeusGhost/lede/commit/3e668936669080ca6f3fcea5534b94d00103291a.patch | patch -p1

--- a/SCRIPTS/02_prepare_package.sh
+++ b/SCRIPTS/02_prepare_package.sh
@@ -5,7 +5,7 @@ clear
 wget -O- https://patch-diff.githubusercontent.com/raw/openwrt/openwrt/pull/3277.patch | patch -p1
 
 #HW-RNG
-wget -O- https://github.com/wevsty/openwrt-nanopi-r2s/commit/e5b5361651940ff5c0c1784dfd0130abec7ab535.patch | patch -p1
+patch -p1 < ../PATCH/new/main/Support-hardware-random-number-generator-for-RK3328.patch
 
 #Crypto（test
 #wget -O- https://github.com/AmadeusGhost/lede/commit/3e668936669080ca6f3fcea5534b94d00103291a.patch | patch -p1

--- a/SCRIPTS/02_prepare_package.sh
+++ b/SCRIPTS/02_prepare_package.sh
@@ -6,6 +6,10 @@ wget -O- https://patch-diff.githubusercontent.com/raw/openwrt/openwrt/pull/3277.
 
 #HW-RNG
 patch --strip=1 --binary --ignore-whitespace < ../PATCH/new/main/Support-hardware-random-number-generator-for-RK3328.patch
+echo '
+CONFIG_HW_RANDOM=y
+CONFIG_HW_RANDOM_ROCKCHIP=y
+' >> ./target/linux/rockchip/armv8/config-5.4
 
 #Crypto（test
 #wget -O- https://github.com/AmadeusGhost/lede/commit/3e668936669080ca6f3fcea5534b94d00103291a.patch | patch -p1

--- a/SCRIPTS/02_prepare_package.sh
+++ b/SCRIPTS/02_prepare_package.sh
@@ -5,11 +5,7 @@ clear
 wget -O- https://patch-diff.githubusercontent.com/raw/openwrt/openwrt/pull/3277.patch | patch -p1
 
 #HW-RNG
-patch --strip=1 --binary --ignore-whitespace < ../PATCH/new/main/Support-hardware-random-number-generator-for-RK3328.patch
-echo '
-CONFIG_HW_RANDOM=y
-CONFIG_HW_RANDOM_ROCKCHIP=y
-' >> ./target/linux/rockchip/armv8/config-5.4
+patch -p1 < ../PATCH/new/main/Support-hardware-random-number-generator-for-RK3328.patch
 
 #Crypto（test
 #wget -O- https://github.com/AmadeusGhost/lede/commit/3e668936669080ca6f3fcea5534b94d00103291a.patch | patch -p1

--- a/SCRIPTS/02_prepare_package.sh
+++ b/SCRIPTS/02_prepare_package.sh
@@ -5,7 +5,7 @@ clear
 wget -O- https://patch-diff.githubusercontent.com/raw/openwrt/openwrt/pull/3277.patch | patch -p1
 
 #HW-RNG
-wget -O- https://patch-diff.githubusercontent.com/raw/jayanta525/openwrt-nanopi-r2s/pull/9.patch | patch -p1
+wget -O- https://github.com/wevsty/openwrt-nanopi-r2s/commit/e5b5361651940ff5c0c1784dfd0130abec7ab535.patch | patch -p1
 
 #Crypto（test
 #wget -O- https://github.com/AmadeusGhost/lede/commit/3e668936669080ca6f3fcea5534b94d00103291a.patch | patch -p1

--- a/SCRIPTS/02_prepare_package.sh
+++ b/SCRIPTS/02_prepare_package.sh
@@ -5,7 +5,7 @@ clear
 wget -O- https://patch-diff.githubusercontent.com/raw/openwrt/openwrt/pull/3277.patch | patch -p1
 
 #HW-RNG
-patch --strip=1 --binary < ../PATCH/new/main/Support-hardware-random-number-generator-for-RK3328.patch
+patch --strip=1 --binary --ignore-whitespace < ../PATCH/new/main/Support-hardware-random-number-generator-for-RK3328.patch
 
 #Crypto（test
 #wget -O- https://github.com/AmadeusGhost/lede/commit/3e668936669080ca6f3fcea5534b94d00103291a.patch | patch -p1

--- a/SCRIPTS/02_prepare_package.sh
+++ b/SCRIPTS/02_prepare_package.sh
@@ -5,7 +5,7 @@ clear
 wget -O- https://patch-diff.githubusercontent.com/raw/openwrt/openwrt/pull/3277.patch | patch -p1
 
 #HW-RNG
-git apply ../PATCH/new/main/Support-hardware-random-number-generator-for-RK3328.patch
+patch --strip=1 --binary < ../PATCH/new/main/Support-hardware-random-number-generator-for-RK3328.patch
 
 #Crypto（test
 #wget -O- https://github.com/AmadeusGhost/lede/commit/3e668936669080ca6f3fcea5534b94d00103291a.patch | patch -p1

--- a/SEED/config_no_docker.seed
+++ b/SEED/config_no_docker.seed
@@ -33,6 +33,8 @@ CONFIG_PACKAGE_kmod-crypto-sha256=y
 CONFIG_PACKAGE_kmod-crypto-sha1=y
 CONFIG_PACKAGE_kmod-crypto-md5=y
 
+CONFIG_PACKAGE_rng-tools=y
+
 CONFIG_PACKAGE_addition-trans-zh=y
 CONFIG_PACKAGE_arm-trusted-firmware-rockchip=y
 CONFIG_PACKAGE_autocore-arm=y


### PR DESCRIPTION
Add /dev/hwrng and rng-tools. This *SHOULD* make SSL and other encrption more safer, by providing more random seed.
PROVIDED *AS IS*.